### PR TITLE
fix for node 9: set-cookie empty string instead of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function createMiddleware(request, options) {
         myRes.headers = applyViaHeader(myRes.headers, opts);
 
         /* eslint no-param-reassign: 0 */
-        myRes.headers['set-cookie'] = rewriteCookieHosts(myRes.headers, opts, req);
+        myRes.headers['set-cookie'] = rewriteCookieHosts(myRes.headers, opts, req) || '';
 
         resp.writeHead(myRes.statusCode, myRes.headers);
 


### PR DESCRIPTION
Could also do a check on the cookie value and not set it at all if it isn't present:
```
const cookieVal = rewriteCookieHosts(myRes.headers, opts, req);
if (cookieVal) {
  myRes.headers['set-cookie'] = cookieVal;
}